### PR TITLE
Fix command aliases

### DIFF
--- a/src/main/java/me/ohowe12/spectatormode/commands/Effects.java
+++ b/src/main/java/me/ohowe12/spectatormode/commands/Effects.java
@@ -26,7 +26,7 @@ public class Effects implements CommandExecutor {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label,
             @NotNull String[] args) {
-        if (label.equalsIgnoreCase("seffect")) {
+        if (command.getName().equalsIgnoreCase("seffect")) {
             if (!(sender instanceof Player)) {
                 Messenger.send(sender, "console-message");
                 return true;

--- a/src/main/java/me/ohowe12/spectatormode/commands/Spectator.java
+++ b/src/main/java/me/ohowe12/spectatormode/commands/Spectator.java
@@ -85,7 +85,7 @@ public class Spectator implements CommandExecutor {
         nightVisionEnabled = plugin.getConfigManager().getBoolean("night-vision");
         conduitEnabled = plugin.getConfigManager().getBoolean("conduit");
 
-        if (label.equalsIgnoreCase("s") || label.equalsIgnoreCase("spectator")) {
+        if (cmd.getName().equalsIgnoreCase("s") || cmd.getName().equalsIgnoreCase("spectator")) {
             processPlayerCommand(sender, args);
             return true;
         }

--- a/src/main/java/me/ohowe12/spectatormode/commands/Speed.java
+++ b/src/main/java/me/ohowe12/spectatormode/commands/Speed.java
@@ -31,7 +31,7 @@ public class Speed implements CommandExecutor {
 
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label,
             @NotNull String @NotNull [] args) {
-        if ((label.equalsIgnoreCase(SPEEDFILLER)) || (label.equalsIgnoreCase("sp"))) {
+        if ((cmd.getName().equalsIgnoreCase(SPEEDFILLER)) || (cmd.getName().equalsIgnoreCase("sp"))) {
             speedCommand(sender, args);
             return true;
         }


### PR DESCRIPTION
I don't actually use this plugin, but I noticed that this plugin is checking commands by label rather than by command name, and it was bothering me. As a result, if a server has any other plugin installed besides SpectatorMode which use commands like `/s` and `/speed`, and they are registered first, it becomes impossible to use the command.

By checking by command name, the exact label doesn't matter anymore, so for example you can run the aliases `/spectatormode:s` or `/spectatormode:speed` and the command will still run as it is intended to in that case.