### PR TITLE
Enforce Y-Level

### DIFF
--- a/src/main/java/me/ohowe12/spectatormode/util/SpectatorEligibilityChecker.java
+++ b/src/main/java/me/ohowe12/spectatormode/util/SpectatorEligibilityChecker.java
@@ -18,7 +18,7 @@ public class SpectatorEligibilityChecker {
         if (player.getHealth() < configManager.getDouble("minimum-health")) {
             return EligibilityStatus.HEALTH;
         }
-        if(configManager.getBoolean("enforce-y") && player.getLocation().getY() < configManager.getInt("y-level")) {
+        if(configManager.getBoolean("enforce-y") && player.getLocation().getY() <= configManager.getInt("y-level")) {
             return EligibilityStatus.YLEVEL;
         }
         double closestAllowed = configManager.getDouble("closest-hostile");

--- a/src/main/java/me/ohowe12/spectatormode/util/SpectatorEligibilityChecker.java
+++ b/src/main/java/me/ohowe12/spectatormode/util/SpectatorEligibilityChecker.java
@@ -18,6 +18,9 @@ public class SpectatorEligibilityChecker {
         if (player.getHealth() < configManager.getDouble("minimum-health")) {
             return EligibilityStatus.HEALTH;
         }
+        if(configManager.getBoolean("enforce-y") && player.getLocation().getY() < configManager.getInt("y-level")) {
+            return EligibilityStatus.YLEVEL;
+        }
         double closestAllowed = configManager.getDouble("closest-hostile");
         if (closestAllowed != 0) {
             for (Entity entity : player.getNearbyEntities(closestAllowed, closestAllowed, closestAllowed)) {
@@ -37,7 +40,8 @@ public class SpectatorEligibilityChecker {
         FALLING("falling-message"),
         HEALTH("health-message"),
         MOB("mob-too-close-message"),
-        WORLDS("world-message");
+        WORLDS("world-message"),
+        YLEVEL("y-level-limit-message");
 
         private final String message;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -134,5 +134,8 @@ mob-too-close-message: '&cYou are too close to a hostile mob to enter spectator 
 #Message sent when a player teleports when not allowed to
 unallowed-teleport-message: '&cYou are not allowed to teleport in spectator mode'
 
+#Message sent when a player is below the enforced y-level limit
+y-level-limit-message: '&cYou are below the enforced y-level limit'
+
 #Get debug logs
 debug: false


### PR DESCRIPTION
If the Y-level limit is enforced and a player below the y limit level executes the /s command, the player will enter spectator but cannot move. 
This has been changed to alert the player informing them they are below the y-level limit instead of changing state to spectator.