### PR TITLE
fix measuring distance between two dimensions

### DIFF
--- a/src/main/java/me/ohowe12/spectatormode/listener/OnMoveListener.java
+++ b/src/main/java/me/ohowe12/spectatormode/listener/OnMoveListener.java
@@ -148,7 +148,11 @@ public class OnMoveListener implements Listener {
         if (toLocation == null) {
             return false;
         }
-        return (originalLocation.distance(toLocation)) > distance;
+        if(originalLocation.getWorld().equals(toLocation.getWorld())) {
+            return (originalLocation.distance(toLocation)) > distance;
+        } else {
+            return true;
+        }
     }
 
     private boolean shouldCancelTeleport(PlayerTeleportEvent teleportEvent) {


### PR DESCRIPTION
if the player is teleported between dimensions while in spectator mode the plugin will attempt to check the distance between two dimensions which returns an NPE