### PR TITLE
add support for supervanish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,10 @@
             <id>aikar</id>
             <url>https://repo.aikar.co/content/groups/aikar/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -180,6 +184,12 @@
             <artifactId>annotations</artifactId>
             <version>22.0.0</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.LeonMangler</groupId>
+            <artifactId>SuperVanish</artifactId>
+            <version>6.2.6-2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/me/ohowe12/spectatormode/SpectatorManager.java
+++ b/src/main/java/me/ohowe12/spectatormode/SpectatorManager.java
@@ -23,15 +23,14 @@
 
 package me.ohowe12.spectatormode;
 
+import de.myzelyam.api.vanish.VanishAPI;
 import me.ohowe12.spectatormode.state.StateHolder;
 import me.ohowe12.spectatormode.util.Messenger;
 
 import me.ohowe12.spectatormode.util.SpectatorEligibilityChecker;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -158,9 +157,15 @@ public class SpectatorManager {
         if (plugin.getConfigManager().getBoolean("conduit")) {
             target.addPotionEffect(CONDUIT);
         }
+        if (plugin.getConfigManager().getBoolean("supervanish-hook")) {
+            VanishAPI.hidePlayer(target);
+        }
     }
 
     public void removeSpectatorEffects(Player target) {
+        if (plugin.getConfigManager().getBoolean("supervanish-hook")) {
+            VanishAPI.showPlayer(target);
+        }
         target.removePotionEffect(NIGHT_VISION.getType());
         target.removePotionEffect(CONDUIT.getType());
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -146,5 +146,10 @@ stand-still-message: '&bStand still to be put into spectator mode!'
 #Message sent when player does not stand still
 moved-message: '&cYou moved! Spectator mode has been cancelled'
 
+#vanish upon entering spectator mode. This will make em un-vanish once they exit spectator mode.
+#the player will be vanished regardless if they have supervanish permissions if you enable this option.
+#if you don't want players to enter vanish when using spectator mode with /gamemode, disable watch-gamemode
+supervanish-hook: false
+
 #Get debug logs
 debug: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: SpectatorMode
 version: ${project.version}
 main: me.ohowe12.spectatormode.SpectatorMode
 api-version: 1.16
-softdepend: [ Multiverse-Core, LuckPerms ]
+softdepend: [ Multiverse-Core, LuckPerms, SuperVanish ]
 load: POSTWORLD
 
 commands:


### PR DESCRIPTION
this will automatically vanish or unvanish players once they enter spectator mode, regardless on the player permissions. this is useful for server owners wanting staff members to use supervanish without influencing gameplay while on it. this feature is disabled by default and can be enabled by changing "supervanish-hook" in the config.

I tested it and works perfectly.