### PR TITLE
Fix logic in unPrepareMobs

### DIFF
--- a/src/main/java/me/ohowe12/spectatormode/state/State.java
+++ b/src/main/java/me/ohowe12/spectatormode/state/State.java
@@ -143,7 +143,7 @@ public class State {
     }
 
     public void unPrepareMobs(Player player) {
-        if (plugin.getConfigManager().getBoolean("mobs") || plugin.isUnitTest()) {
+        if (!plugin.getConfigManager().getBoolean("mobs") || plugin.isUnitTest()) {
             return;
         }
         @NotNull Location loc = getPlayerLocation();


### PR DESCRIPTION
The config check in unPrepareMobs was the inverse of prepareMobs, so
saved mobs were getting setRemoveWhenFarAway(false), but were never
getting set back to setRemoveWhenFarAway(true) when exiting spectator
mode. This was causing hundreds and hundreds of persistent mobs to
accumulate and bog down the server.

This does not remove mobs that have been persisted in the past, but
will prevent new persistent mobs.